### PR TITLE
Issue #11: Allow to create multiple disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A brief explanation of what the config parameters mean:
  * `remote_password` - the password for the XenServer host being used.
  * `boot_command` - a list of commands to be sent to the instance over XenServer VNC connection to VM.
  * `boot_wait` - how long to wait for the VM isntance to initially start
- * `disk_size` - the size of the disk the VM should be created with, in MB.
+ * `disk_size` - the size of the disk the VM should be created with, in MB. If present, this takes precedence and overrides vm_disks (for backwards compatibility)
  * `iso_url` - the url from which to download the ISO and place it in the iso_sr
  * `iso_name` - the name of the ISO visible on a ISO SR connected to the XenServer host, or the name to assign to it upon download.
  * `iso_sr` - the name of the ISO SR a downloaded ISO should be placed in
@@ -98,6 +98,7 @@ A brief explanation of what the config parameters mean:
  * `vm_name` - the name that should be given to the created VM.
  * `vm_memory` - the static memory configuration for the VM, in MB.
  * `vm_vcpus` - the number of vCPUs to assign during build
+ * `vm_disks` - a nested array of disk name: capacity pairs. Allows creating more than one virtual disk, and assigning each a name. If disk_size is also present, it takes priority and this setting is completely ignored. Using arrays enforces drive creation order, which can be very important for matching up to device names in Kickstart scripts, for example.
  * `nfs_mount` - Used for VHD artifacts, the NFS mount for the sr_name
 
 Once you've updated the config file with your own parameters, you can use packer to build this VM with the following command:

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,9 @@ rm -rf pkg/*
 rm -rf ${GOPATH}/pkg/*
 mkdir -p bin/
 
+# Install gox, if not already present
+go get github.com/mitchellh/gox
+
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \

--- a/examples/centos-6.6.json
+++ b/examples/centos-6.6.json
@@ -10,7 +10,6 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos6-ks.cfg<enter><wait>"
       ],
       "boot_wait": "10s",
-      "disk_size": 40960,
       "http_directory": "http",
       "iso_checksum": "4ed6c56d365bd3ab12cd88b8a480f4a62e7c66d2",
       "iso_checksum_type": "sha1",
@@ -21,7 +20,10 @@
       "ssh_password": "vmpassword",
       "ssh_wait_timeout": "10000s",
       "vm_name": "packer-centos-6.6-x86_64",
-      "vm_description": "Build time: {{isotime}}"
+      "vm_description": "Build time: {{isotime}}",
+      "vm_disks": [
+        ["rootvol", "40000"]
+      ]
     }
   ],
 


### PR DESCRIPTION
Fixes #11 

There's a bunch of random whitespace changes that gofmt automatically made. The meat of what was done is adding a new setting, "vm_disks". Which takes a nested array and allows you to create as many virtual disks as you want, specifying their label in XenServer and capacity. They're created in the order they appear in the array.

```
"vm_disks": [
  ["rootvol", "20480"],
  ["swapvol", "2048"]
],
```

It's backwards compatible with the existing disk_size option. If that's present, vm_disks is ignored.
